### PR TITLE
TP-63: Päivitysrajapinnan skeemassa matkustusasiakirjan pakollisuus pois

### DIFF
--- a/schemas/information_update.json
+++ b/schemas/information_update.json
@@ -213,8 +213,7 @@
             "lastName",
             "firstNames",
             "birthdate",
-            "nationality",
-            "identificationDocumentId"
+            "nationality"
           ]
         }
       ],


### PR DESCRIPTION
Päivitysrajapinnan skeemassa matkustusasiakirja oli virheellisesti pakollinen, muutetaan siten, ettei se ole pakollinen, vaikka hetua ei annettaisikaan.